### PR TITLE
Left only string key/value/pairs events.

### DIFF
--- a/examples/android/src/main/java/org/alohastats/demoapp/MainActivity.java
+++ b/examples/android/src/main/java/org/alohastats/demoapp/MainActivity.java
@@ -65,10 +65,6 @@ public class MainActivity extends Activity {
   protected void onResume() {
     super.onResume();
 
-    // Basic call to track user time spent in the app.
-    // Should be added to each activity you want to track together with Statistics.onPause().
-    Statistics.onResume(this);
-
     // TODO: send detailed system info statistics automatically on startup
 
     // Very simple event.
@@ -93,12 +89,15 @@ public class MainActivity extends Activity {
     }
     // Event with a key=value pairs but passed as an array.
     Statistics.logEvent("app", arr);
+
+    // Example event to track user activity.
+    Statistics.logEvent("$onResume", getLocalClassName());
   }
 
   @Override
   protected void onPause() {
     super.onPause();
-    Statistics.onPause(this);
+    Statistics.logEvent("$onPause", getLocalClassName());
   }
 
   public void onSendButtonClicked(View v) {

--- a/src/aloha_stats.h
+++ b/src/aloha_stats.h
@@ -66,7 +66,7 @@ class Stats {
     if (debug_mode_) {
       LOG("LogEvent:", event_name);
     }
-    AlohalyticsCompatibilityKeyEvent event;
+    AlohalyticsKeyEvent event;
     event.key = event_name;
     std::ostringstream sstream;
     {
@@ -79,7 +79,7 @@ class Stats {
     if (debug_mode_) {
       LOG("LogEvent:", event_name, "=", event_value);
     }
-    AlohalyticsCompatibilityKeyValueEvent event;
+    AlohalyticsKeyValueEvent event;
     event.key = event_name;
     event.value = event_value;
     std::ostringstream sstream;
@@ -93,7 +93,7 @@ class Stats {
     if (debug_mode_) {
       LOG("LogEvent:", event_name, "=", value_pairs);
     }
-    AlohalyticsCompatibilityKeyPairsEvent event;
+    AlohalyticsKeyPairsEvent event;
     event.key = event_name;
     event.pairs = value_pairs;
     std::ostringstream sstream;
@@ -101,14 +101,6 @@ class Stats {
       cereal::BinaryOutputArchive(sstream) << event;
     }
     PushMessageViaQueue(sstream.str());
-  }
-
-  void LogJSONEvent(std::string const& event_in_json) const {
-    if (debug_mode_) {
-      LOG("LogJSONEvent:", event_in_json);
-    }
-    // TODO(AlexZ): construct C++ event class from json with Cereal.
-    PushMessageViaQueue(event_in_json);
   }
 
   void DebugMode(bool enable) {

--- a/src/android/src/main/java/org/alohastats/lib/Statistics.java
+++ b/src/android/src/main/java/org/alohastats/lib/Statistics.java
@@ -27,10 +27,6 @@ package org.alohastats.lib;
 import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.util.Log;
-
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.io.File;
 import java.util.Map;
@@ -75,30 +71,6 @@ public class Statistics {
       array[index++] = entry.getValue();
     }
     logEvent(eventName, array);
-  }
-
-  public static native void logJSONEvent(final String cppClassInWrappedJSONFormat);
-
-  public static void logJSONEvent(JSONObject eventShouldMatchCPPClass) {
-    // Wrap event as C++ Cereal requires it.
-    try {
-      logJSONEvent((new JSONObject().put("value0", eventShouldMatchCPPClass)).toString());
-    } catch (JSONException ex) {
-      if (sDebugModeEnabled) {
-        if (ex.getMessage() != null) {
-          Log.e(TAG, ex.getMessage());
-        }
-        ex.printStackTrace();
-      }
-    }
-  }
-
-  static public void onResume(Activity activity) {
-    logEvent("$onResume", activity.getLocalClassName());
-  }
-
-  static public void onPause(Activity activity) {
-    logEvent("$onPause", activity.getLocalClassName());
   }
 
   // http://stackoverflow.com/a/7929810

--- a/src/android/src/main/jni/jni_wrapper.cc
+++ b/src/android/src/main/jni/jni_wrapper.cc
@@ -103,11 +103,6 @@ JNIEXPORT void JNICALL Java_org_alohastats_lib_Statistics_logEvent__Ljava_lang_S
   g_stats->LogEvent(ToStdString(env, eventName), map);
 }
 
-JNIEXPORT void JNICALL
-    Java_org_alohastats_lib_Statistics_logJSONEvent(JNIEnv* env, jclass, jstring jsonString) {
-  g_stats->LogJSONEvent(ToStdString(env, jsonString));
-}
-
 #define CLEAR_AND_RETURN_FALSE_ON_EXCEPTION \
   if (env->ExceptionCheck()) {              \
     env->ExceptionDescribe();               \

--- a/src/event_base.h
+++ b/src/event_base.h
@@ -31,71 +31,10 @@ struct AlohalyticsBaseEvent {
   // To use polymorphism on a server side.
   virtual ~AlohalyticsBaseEvent() = default;
 };
-CEREAL_REGISTER_TYPE(AlohalyticsBaseEvent);
+CEREAL_REGISTER_TYPE_WITH_NAME(AlohalyticsBaseEvent, "b");
 
-// Base for all Android-specific events.
-struct AlohalyticsAndroidBaseEvent : AlohalyticsBaseEvent {
-  template <class Archive> void serialize(Archive& ar) {
-    AlohalyticsBaseEvent::serialize(ar);
-  }
-};
-CEREAL_REGISTER_TYPE(AlohalyticsAndroidBaseEvent);
-
-// Base for all iOS-specific events.
-struct AlohalyticsiOSBaseEvent : public AlohalyticsBaseEvent {
-  template <class Archive> void serialize(Archive& ar) {
-    AlohalyticsBaseEvent::serialize(ar);
-  }
-};
-CEREAL_REGISTER_TYPE(AlohalyticsiOSBaseEvent);
-
-// Delivers Android-specific Ids.
-struct AlohalyticsAndroidIdsEvent : public AlohalyticsAndroidBaseEvent {
-  std::string google_advertising_id;
-  std::string android_id;
-  std::string device_id;
-  std::string sim_serial_number;
-
-  template <class Archive> void serialize(Archive& ar) {
-    AlohalyticsAndroidBaseEvent::serialize(ar);
-    ar(CEREAL_NVP(google_advertising_id),
-       CEREAL_NVP(android_id),
-       CEREAL_NVP(device_id),
-       CEREAL_NVP(sim_serial_number));
-  }
-};
-CEREAL_REGISTER_TYPE(AlohalyticsAndroidIdsEvent);
-
-// Base for all user-interface screens (modes).
-struct AlohalyticsBaseModeEvent : public AlohalyticsBaseEvent {
-  std::string mode_name;
-
-  template <class Archive> void serialize(Archive& ar) {
-    AlohalyticsBaseEvent::serialize(ar);
-    ar(CEREAL_NVP(mode_name));
-  }
-};
-CEREAL_REGISTER_TYPE(AlohalyticsBaseModeEvent);
-
-// Activity.onResume() on Android.
-struct AlohalyticsModeActivatedEvent : public AlohalyticsBaseModeEvent {
-  template <class Archive> void serialize(Archive& ar) {
-    AlohalyticsBaseModeEvent::serialize(ar);
-  }
-};
-CEREAL_REGISTER_TYPE(AlohalyticsModeActivatedEvent);
-
-// Activity.onPause() on Android.
-struct AlohalyticsModeDeactivatedEvent : public AlohalyticsBaseModeEvent {
-  template <class Archive> void serialize(Archive& ar) {
-    AlohalyticsBaseModeEvent::serialize(ar);
-  }
-};
-CEREAL_REGISTER_TYPE(AlohalyticsModeDeactivatedEvent);
-
-// *** Events compatible with other statistic systems ***
 // Simple event with a string name (key) only.
-struct AlohalyticsCompatibilityKeyEvent : public AlohalyticsBaseEvent {
+struct AlohalyticsKeyEvent : public AlohalyticsBaseEvent {
   std::string key;
 
   template <class Archive> void serialize(Archive& ar) {
@@ -103,28 +42,28 @@ struct AlohalyticsCompatibilityKeyEvent : public AlohalyticsBaseEvent {
     ar(CEREAL_NVP(key));
   }
 };
-CEREAL_REGISTER_TYPE(AlohalyticsCompatibilityKeyEvent);
+CEREAL_REGISTER_TYPE_WITH_NAME(AlohalyticsKeyEvent, "k");
 
 // Simple event with a string key/value pair.
-struct AlohalyticsCompatibilityKeyValueEvent : public AlohalyticsCompatibilityKeyEvent {
+struct AlohalyticsKeyValueEvent : public AlohalyticsKeyEvent {
   std::string value;
 
   template <class Archive> void serialize(Archive& ar) {
-    AlohalyticsCompatibilityKeyEvent::serialize(ar);
+    AlohalyticsKeyEvent::serialize(ar);
     ar(CEREAL_NVP(value));
   }
 };
-CEREAL_REGISTER_TYPE(AlohalyticsCompatibilityKeyValueEvent);
+CEREAL_REGISTER_TYPE_WITH_NAME(AlohalyticsKeyValueEvent, "v");
 
 // Simple event with a string key and map<string, string> value.
-struct AlohalyticsCompatibilityKeyPairsEvent : public AlohalyticsCompatibilityKeyEvent {
+struct AlohalyticsKeyPairsEvent : public AlohalyticsKeyEvent {
   std::map<std::string, std::string> pairs;
 
   template <class Archive> void serialize(Archive& ar) {
-    AlohalyticsCompatibilityKeyEvent::serialize(ar);
+    AlohalyticsKeyEvent::serialize(ar);
     ar(CEREAL_NVP(pairs));
   }
 };
-CEREAL_REGISTER_TYPE(AlohalyticsCompatibilityKeyPairsEvent);
+CEREAL_REGISTER_TYPE_WITH_NAME(AlohalyticsKeyPairsEvent, "p");
 
 #endif  // EVENT_BASE_H


### PR DESCRIPTION
@dkorolev PTAL

events_base.h contains production-ready types of events and can be used on a server-side.
